### PR TITLE
Changed make flash_ota to make lws_flash_ota in README.md

### DIFF
--- a/README.md~
+++ b/README.md~
@@ -62,7 +62,7 @@ Clone and bring in the lws submodule (it's unpatched lws master)
 ```
 
 ```
- $ make lws_flash_ota ; make monitor
+ $ make flash_ota ; make monitor
 ```
 
 ## Using the lws test apps


### PR DESCRIPTION
If the PR to change flash_ota to lws_flash_ota in libwebsockets is accepted, then the README.md should be updated with this PR to reflect it.